### PR TITLE
Feature/calc avg qvolume

### DIFF
--- a/DRL_POL/Env3D_MARL_channel.py
+++ b/DRL_POL/Env3D_MARL_channel.py
@@ -2031,9 +2031,17 @@ class Environment(Environment):
                     directory_post,
                     "rewards",
                 )
-                output_file_name = f"rewards_{self.host}_EP_{self.episode_number}.csv"
-                output_file_path = os.path.join(
-                    output_folder_path_reward, output_file_name
+                qratio_output_file_name = (
+                    f"qratios_{self.host}_EP_{self.episode_number}.csv"
+                )
+                qratio_output_file_path = os.path.join(
+                    output_folder_path_reward, qratio_output_file_name
+                )
+                reward_output_file_name = (
+                    f"rewards_{self.host}_EP_{self.episode_number}.csv"
+                )
+                reward_output_file_path = os.path.join(
+                    output_folder_path_reward, reward_output_file_name
                 )
 
                 if not os.path.exists(directory_vtk):
@@ -2042,7 +2050,7 @@ class Environment(Environment):
                     )
                 if not os.path.exists(averaged_data_path):
                     raise ValueError(
-                        f"{self.ENV_ID}: execute: File {averaged_data_path} does not exist for pre-calculated data!!!"
+                        f"{self.ENV_ID}: execute: Directory {averaged_data_path} does not exist for pre-calculated data!!!"
                     )
                 if not os.path.exists(output_folder_path_reward):
                     os.makedirs(output_folder_path_reward)
@@ -2060,7 +2068,8 @@ class Environment(Environment):
                     f"--nx {reward_params['nx_Qs']} "
                     f"--nz {reward_params['nz_Qs']} "
                     f"--averaged_data_path {averaged_data_path} "
-                    f"--output_file {output_file_path}"
+                    f"--output_qratio_file {qratio_output_file_path} "
+                    f"--output_reward_file {reward_output_file_path} "
                 )
                 self.log(
                     logging.INFO,

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -1,0 +1,174 @@
+import os
+import argparse
+import logging
+import numpy as np
+import xml.etree.ElementTree as ET  # For XML parsing
+import pyvista as pv  # For reading and processing mesh data
+import pandas as pd  # For data manipulation and DataFrame creation
+from typing import Tuple, List, Dict
+from pathlib import Path
+import gc
+from env_utils import agent_index_2d_to_1d
+
+from coco_calc_reward import (
+    normalize_all_single,
+    process_velocity_data_single,
+    detect_Q_events_single,
+)
+
+from logging_config import configure_logger, DEFAULT_LOGGING_LEVEL
+
+# Set up logger
+logger = configure_logger("calc_avg_qvolume", default_level=DEFAULT_LOGGING_LEVEL)
+
+logger.info("calc_avg_qvolume.py: Logging level set to %s", logger.level)
+
+
+def load_data_for_timestep(directory: str, file_name: str) -> pd.DataFrame:
+    """
+    Load data from a specific PVTU file and convert it into a Pandas DataFrame.
+
+    Parameters:
+    - directory (str): The path to the directory containing the PVD and PVTU files.
+    - file_name (str): The name of the PVTU file to be loaded.
+
+    Returns:
+    - df (pd.DataFrame): DataFrame with columns for spatial coordinates (x, y, z) and velocity components (u, v, w).
+    """
+    logger.info(f"Loading data from PVTU file: {file_name}")
+    path = os.path.join(directory, file_name)
+    mesh = pv.read(path)  # Read the mesh data from the PVTU file
+
+    # Extract the spatial coordinates and velocity components from the mesh
+    points = mesh.points  # x, y, z coordinates
+    u, v, w = mesh["VELOC"].T  # Transpose to separate the velocity components (u, v, w)
+
+    # Create a DataFrame with the extracted data
+    df = pd.DataFrame(
+        {
+            "x": points[:, 0],
+            "y": points[:, 1],
+            "z": points[:, 2],
+            "u": u,
+            "v": v,
+            "w": w,
+        }
+    )
+
+    logger.info(f"Data from {file_name} loaded into DataFrame.")
+    return df
+
+
+def create_timestep_file_map(pvd_path: str) -> Dict[str, float]:
+    """
+    Create a mapping of timesteps to their corresponding PVTU files.
+
+    Parameters:
+    - pvd_path (str): Path to the PVD file.
+
+    Returns:
+    - timestep_file_map (dict): Dictionary mapping PVTU file names to timesteps.
+    """
+    tree = ET.parse(pvd_path)
+    root = tree.getroot()
+    timestep_file_map = {
+        dataset.attrib["file"]: float(dataset.attrib["timestep"])
+        for dataset in root.find("Collection")
+    }
+    return timestep_file_map
+
+
+def calculate_avg_qevent_ratio(
+    directory: str, averaged_data_path: str, H: float, num_timesteps: int
+) -> None:
+    pvd_path = os.path.join(directory, "channel.pvd")
+    timestep_file_map = create_timestep_file_map(pvd_path)
+
+    # Ensure we process only the specified number of timesteps from the end
+    timesteps = list(timestep_file_map.items())[-num_timesteps:]
+
+    precalc_values = pd.read_csv(
+        os.path.join(averaged_data_path, "calculated_values.csv")
+    )
+    u_tau = precalc_values.iloc[0, 1]
+    delta_tau = precalc_values.iloc[1, 1]
+    averaged_data = pd.read_csv(os.path.join(averaged_data_path, "averaged_data.csv"))
+
+    q_event_ratios = []
+
+    for file_name, timestep in timesteps:
+        df = load_data_for_timestep(directory, file_name)
+        normalized_df = normalize_all_single((timestep, df), u_tau, delta_tau)[1]
+        processed_df = process_velocity_data_single(
+            (timestep, normalized_df), averaged_data
+        )[1]
+        q_event_df = detect_Q_events_single((timestep, processed_df), averaged_data, H)[
+            1
+        ]
+
+        # Calculate the global Q event volume ratio
+        total_points = len(q_event_df)
+        q_event_count = q_event_df["Q"].sum()
+        q_event_ratio = q_event_count / total_points if total_points > 0 else 0
+
+        q_event_ratios.append({"timestep": timestep, "q_event_ratio": q_event_ratio})
+
+        # Clear memory
+        del df, normalized_df, processed_df, q_event_df
+        gc.collect()
+
+    q_event_ratios_df = pd.DataFrame(q_event_ratios)
+    average_q_event_ratio = q_event_ratios_df["q_event_ratio"].mean()
+    std_dev_q_event_ratio = q_event_ratios_df["q_event_ratio"].std()
+
+    # Save the results
+    q_event_ratios_df.to_csv("q_event_ratios.csv", index=False)
+    summary_df = pd.DataFrame(
+        {
+            "average_q_event_ratio": [average_q_event_ratio],
+            "std_dev_q_event_ratio": [std_dev_q_event_ratio],
+        }
+    )
+    summary_df.to_csv("q_event_summary.csv", index=False)
+
+    logger.info(f"Average Q Event Volume Ratio: {average_q_event_ratio}")
+    logger.info(f"Standard Deviation of Q Event Volume Ratio: {std_dev_q_event_ratio}")
+
+
+if __name__ == "__main__":
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser(
+        description="Calculate the average Q event volume ratio for the last N timesteps."
+    )
+    parser.add_argument(
+        "--directory",
+        type=str,
+        required=True,
+        help="Path to the directory containing the PVD and PVTU files.",
+    )
+    parser.add_argument(
+        "--averaged_data_path",
+        type=str,
+        required=True,
+        help="Path to the directory containing the averaged data.",
+    )
+    parser.add_argument(
+        "--H",
+        type=float,
+        required=True,
+        help="Threshold value for Q event detection.",
+    )
+    parser.add_argument(
+        "--num_timesteps",
+        type=int,
+        required=True,
+        help="Number of timesteps to process from the end.",
+    )
+    args = parser.parse_args()
+
+    directory = args.directory
+    averaged_data_path = args.averaged_data_path
+    H = args.H
+    num_timesteps = args.num_timesteps
+
+    calculate_avg_qevent_ratio(directory, averaged_data_path, H, num_timesteps)

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -98,13 +98,28 @@ def calculate_avg_qevent_ratio(
 
     for file_name, timestep in timesteps:
         df = load_data_for_timestep(directory, file_name)
+        logger.debug(
+            "calculate_avg_qevent_ratio: Loaded data for timestep %s", timestep
+        )
+
         normalized_df = normalize_all_single((timestep, df), u_tau, delta_tau)[1]
+        logger.debug(
+            "calculate_avg_qevent_ratio: Normalized data for timestep %s", timestep
+        )
+
         processed_df = process_velocity_data_single(
             (timestep, normalized_df), averaged_data
         )[1]
+        logger.debug(
+            "calculate_avg_qevent_ratio: Processed data for timestep %s", timestep
+        )
+
         q_event_df = detect_Q_events_single((timestep, processed_df), averaged_data, H)[
             1
         ]
+        logger.debug(
+            "calculate_avg_qevent_ratio: Detected Q events for timestep %s", timestep
+        )
 
         # Calculate the global Q event volume ratio
         total_points = len(q_event_df)

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -35,7 +35,7 @@ def load_data_for_timestep(directory: str, file_name: str) -> pd.DataFrame:
     Returns:
     - df (pd.DataFrame): DataFrame with columns for spatial coordinates (x, y, z) and velocity components (u, v, w).
     """
-    logger.info(f"Loading data from PVTU file: {file_name}")
+    logger.info("load_data_for_timestep: %s: Loading data from PVTU file", file_name)
     path = os.path.join(directory, file_name)
     mesh = pv.read(path)  # Read the mesh data from the PVTU file
 
@@ -69,7 +69,7 @@ def load_data_for_timestep(directory: str, file_name: str) -> pd.DataFrame:
         nan_v_count,
     )
 
-    logger.info(f"Data from {file_name} loaded into DataFrame.")
+    logger.info("load_data_for_timestep: %s: Data loaded into DataFrame", file_name)
     return df
 
 
@@ -83,12 +83,16 @@ def create_timestep_file_map(pvd_path: str) -> Dict[str, float]:
     Returns:
     - timestep_file_map (dict): Dictionary mapping PVTU file names to timesteps.
     """
+    logger.debug("create_timestep_file_map: Parsing PVD file %s", pvd_path)
     tree = ET.parse(pvd_path)
     root = tree.getroot()
     timestep_file_map = {
         dataset.attrib["file"]: float(dataset.attrib["timestep"])
         for dataset in root.find("Collection")
     }
+    logger.debug(
+        "create_timestep_file_map: timestep file map created from %s", pvd_path
+    )
     return timestep_file_map
 
 
@@ -99,6 +103,8 @@ def calculate_avg_qevent_ratio(
     num_timesteps: int,
     tolerance: float = 1e-3,
 ) -> None:
+    logger.debug("calculate_avg_qevent_ratio: Starting calculation...")
+
     pvd_path = os.path.join(directory, "channel.pvd")
     timestep_file_map = create_timestep_file_map(pvd_path)
     # Ensure we have at least num_timesteps timesteps
@@ -164,7 +170,7 @@ def calculate_avg_qevent_ratio(
         os.path.join(averaged_data_path, "q_event_ratio_history.csv"), index=False
     )
     logger.info(
-        "Q event ratio history saved to %s",
+        "calculate_avg_qevent_ratio: Q event ratio history saved to %s",
         os.path.join(averaged_data_path, "q_event_ratio_history.csv"),
     )
 
@@ -179,13 +185,21 @@ def calculate_avg_qevent_ratio(
         os.path.join(averaged_data_path, "q_event_ratio_summary.csv"), index=False
     )
     logger.info(
-        "Q event ratio summary saved to %s",
+        "calculate_avg_qevent_ratio: Q event ratio summary saved to %s",
         os.path.join(averaged_data_path, "q_event_ratio_summary.csv"),
     )
 
-    logger.info(f"Average Q Event Volume Ratio: {average_q_event_ratio}")
-    logger.info(f"Standard Deviation of Q Event Volume Ratio: {std_dev_q_event_ratio}")
-    logger.info(f"H value used: {H}\n")  # Log the H value used
+    logger.info(
+        "calculate_avg_qevent_ratio: Average Q Event Volume Ratio: %f",
+        average_q_event_ratio,
+    )
+    logger.info(
+        "calculate_avg_qevent_ratio: Standard Deviation of Q Event Volume Ratio: %f",
+        std_dev_q_event_ratio,
+    )
+    logger.info(
+        "calculate_avg_qevent_ratio: H value used: %f", H
+    )  # Log the H value used
 
 
 if __name__ == "__main__":
@@ -217,8 +231,10 @@ if __name__ == "__main__":
         required=True,
         help="Number of timesteps to process from the end.",
     )
+    logger.debug("Parsing Arguments...")
     args = parser.parse_args()
-
+    logger.debug("Arguments Parsed!")
+    logger.debug("Arguments: \n%s\n", args)
     directory = args.directory
     averaged_data_path = args.averaged_data_path
     H = args.H
@@ -231,5 +247,6 @@ if __name__ == "__main__":
     # )
     # H = 3.0
     # num_timesteps = 10
-
+    logger.debug("Calling `calculate_avg_qevent_ratio`...")
     calculate_avg_qevent_ratio(directory, averaged_data_path, H, num_timesteps)
+    logger.debug("Finished calc_avg_qvolume.py script!!!")

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -55,6 +55,12 @@ def load_data_for_timestep(directory: str, file_name: str) -> pd.DataFrame:
         }
     )
 
+    # Log NaN counts
+    nan_u_count = df["u"].isna().sum()
+    nan_v_count = df["v"].isna().sum()
+    logger.debug("%s: Number of NaNs in 'u' after loading: %d", file_name, nan_u_count)
+    logger.debug("%s: Number of NaNs in 'v' after loading: %d", file_name, nan_v_count)
+
     logger.info(f"Data from {file_name} loaded into DataFrame.")
     return df
 

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -35,7 +35,7 @@ def load_data_for_timestep(directory: str, file_name: str) -> pd.DataFrame:
     Returns:
     - df (pd.DataFrame): DataFrame with columns for spatial coordinates (x, y, z) and velocity components (u, v, w).
     """
-    logger.info("load_data_for_timestep: %s: Loading data from PVTU file", file_name)
+    logger.info("load_data_for_timestep: %s: Data Loading...", file_name)
     path = os.path.join(directory, file_name)
     mesh = pv.read(path)  # Read the mesh data from the PVTU file
 
@@ -69,7 +69,7 @@ def load_data_for_timestep(directory: str, file_name: str) -> pd.DataFrame:
         nan_v_count,
     )
 
-    logger.info("load_data_for_timestep: %s: Data loaded into DataFrame", file_name)
+    logger.info("load_data_for_timestep: %s: Data loaded!!!", file_name)
     return df
 
 

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -58,8 +58,16 @@ def load_data_for_timestep(directory: str, file_name: str) -> pd.DataFrame:
     # Log NaN counts
     nan_u_count = df["u"].isna().sum()
     nan_v_count = df["v"].isna().sum()
-    logger.debug("load_data_for_timestep: %s: Number of NaNs in 'u' after loading: %d", file_name, nan_u_count)
-    logger.debug("load_data_for_timestep: %s: Number of NaNs in 'v' after loading: %d", file_name, nan_v_count)
+    logger.debug(
+        "load_data_for_timestep: %s: Number of NaNs in 'u' after loading: %d",
+        file_name,
+        nan_u_count,
+    )
+    logger.debug(
+        "load_data_for_timestep: %s: Number of NaNs in 'v' after loading: %d",
+        file_name,
+        nan_v_count,
+    )
 
     logger.info(f"Data from {file_name} loaded into DataFrame.")
     return df

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -35,7 +35,7 @@ def load_data_for_timestep(directory: str, file_name: str) -> pd.DataFrame:
     Returns:
     - df (pd.DataFrame): DataFrame with columns for spatial coordinates (x, y, z) and velocity components (u, v, w).
     """
-    logger.info("load_data_for_timestep: %s: Data Loading...", file_name)
+    logger.debug("load_data_for_timestep: %s: Data Loading...", file_name)
     path = os.path.join(directory, file_name)
     mesh = pv.read(path)  # Read the mesh data from the PVTU file
 
@@ -69,7 +69,7 @@ def load_data_for_timestep(directory: str, file_name: str) -> pd.DataFrame:
         nan_v_count,
     )
 
-    logger.info("load_data_for_timestep: %s: Data loaded!!!", file_name)
+    logger.debug("load_data_for_timestep: %s: Data loaded!!!", file_name)
     return df
 
 
@@ -127,27 +127,23 @@ def calculate_avg_qevent_ratio(
 
     for file_name, timestep in timesteps:
         df = load_data_for_timestep(directory, file_name)
-        logger.debug(
-            "calculate_avg_qevent_ratio: Loaded data for timestep %s", timestep
-        )
+        logger.info("calculate_avg_qevent_ratio: %s: Data Loaded!!!", timestep)
 
         normalized_df = normalize_all_single((timestep, df), u_tau, delta_tau)[1]
-        logger.debug(
-            "calculate_avg_qevent_ratio: Normalized data for timestep %s", timestep
-        )
+        logger.debug("calculate_avg_qevent_ratio: %s: Data Normalized!!!", timestep)
 
         processed_df = process_velocity_data_single(
             (timestep, normalized_df), averaged_data, tolerance
         )[1]
-        logger.debug(
-            "calculate_avg_qevent_ratio: Processed data for timestep %s", timestep
-        )
+        logger.debug("calculate_avg_qevent_ratio: %s: Data Processed!!!", timestep)
 
         q_event_df = detect_Q_events_single((timestep, processed_df), averaged_data, H)[
             1
         ]
-        logger.debug(
-            "calculate_avg_qevent_ratio: Detected Q events for timestep %s", timestep
+        logger.info(
+            "calculate_avg_qevent_ratio: %s: %d Q events Detected!!!",
+            timestep,
+            q_event_df["Q"].sum(),
         )
 
         # Calculate the global Q event volume ratio
@@ -156,6 +152,13 @@ def calculate_avg_qevent_ratio(
         q_event_ratio = q_event_count / total_points if total_points > 0 else 0
 
         q_event_ratios.append({"timestep": timestep, "q_event_ratio": q_event_ratio})
+        logger.info(
+            "calculate_avg_qevent_ratio: %s: Q event ratio: %f", timestep, q_event_ratio
+        )
+
+        logger.info(
+            "calculate_avg_qevent_ratio: %s: Finished Calculations!!!", timestep
+        )
 
         # Clear memory
         del df, normalized_df, processed_df, q_event_df

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -93,7 +93,11 @@ def create_timestep_file_map(pvd_path: str) -> Dict[str, float]:
 
 
 def calculate_avg_qevent_ratio(
-    directory: str, averaged_data_path: str, H: float, num_timesteps: int
+    directory: str,
+    averaged_data_path: str,
+    H: float,
+    num_timesteps: int,
+    tolerance: float = 1e-3,
 ) -> None:
     pvd_path = os.path.join(directory, "channel.pvd")
     timestep_file_map = create_timestep_file_map(pvd_path)
@@ -122,7 +126,7 @@ def calculate_avg_qevent_ratio(
         )
 
         processed_df = process_velocity_data_single(
-            (timestep, normalized_df), averaged_data
+            (timestep, normalized_df), averaged_data, tolerance
         )[1]
         logger.debug(
             "calculate_avg_qevent_ratio: Processed data for timestep %s", timestep

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -58,8 +58,8 @@ def load_data_for_timestep(directory: str, file_name: str) -> pd.DataFrame:
     # Log NaN counts
     nan_u_count = df["u"].isna().sum()
     nan_v_count = df["v"].isna().sum()
-    logger.debug("%s: Number of NaNs in 'u' after loading: %d", file_name, nan_u_count)
-    logger.debug("%s: Number of NaNs in 'v' after loading: %d", file_name, nan_v_count)
+    logger.debug("load_data_for_timestep: %s: Number of NaNs in 'u' after loading: %d", file_name, nan_u_count)
+    logger.debug("load_data_for_timestep: %s: Number of NaNs in 'v' after loading: %d", file_name, nan_v_count)
 
     logger.info(f"Data from {file_name} loaded into DataFrame.")
     return df

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -187,11 +187,11 @@ if __name__ == "__main__":
     num_timesteps = args.num_timesteps
 
     # HARDCODED PATHS FOR TESTING
-    directory = "/scratch/pietero/baseline/prados_recent/re180_min_channel_900_calculating_Ubar/vtk_for_average/vtk"
-    averaged_data_path = (
-        "/scratch/pietero/andres_clone/DRL_POL/alya_files/baseline/calculated_data/"
-    )
-    H = 3.0
-    num_timesteps = 10
+    # directory = "/scratch/pietero/baseline/prados_recent/re180_min_channel_900_calculating_Ubar/vtk_for_average/vtk"
+    # averaged_data_path = (
+    #     "/scratch/pietero/andres_clone/DRL_POL/alya_files/baseline/calculated_data/"
+    # )
+    # H = 3.0
+    # num_timesteps = 10
 
     calculate_avg_qevent_ratio(directory, averaged_data_path, H, num_timesteps)

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -21,7 +21,7 @@ from logging_config import configure_logger, DEFAULT_LOGGING_LEVEL
 # Set up logger
 logger = configure_logger("calc_avg_qvolume", default_level=DEFAULT_LOGGING_LEVEL)
 
-logger.info("calc_avg_qvolume.py: Logging level set to %s", logger.level)
+logger.info("calc_avg_qvolume.py: Logging level set to %s\n", logger.level)
 
 
 def load_data_for_timestep(directory: str, file_name: str) -> pd.DataFrame:

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -171,4 +171,10 @@ if __name__ == "__main__":
     H = args.H
     num_timesteps = args.num_timesteps
 
+    # HARDCODED PATHS FOR TESTING
+    directory = "/scratch/pietero/baseline/prados_recent/re180_min_channel_900_calculating_Ubar/vtk_for_average/vtk"
+    averaged_data_path = "/scratch/pietero/andres_clone/DRL_POL/alya_files/baseline/calculated_data/"
+    H = 3.0
+    num_timesteps = 10
+
     calculate_avg_qevent_ratio(directory, averaged_data_path, H, num_timesteps)

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -101,6 +101,11 @@ def calculate_avg_qevent_ratio(
 ) -> None:
     pvd_path = os.path.join(directory, "channel.pvd")
     timestep_file_map = create_timestep_file_map(pvd_path)
+    # Ensure we have at least num_timesteps timesteps
+    if len(timestep_file_map) < num_timesteps:
+        raise ValueError(
+            f"Number of timesteps in the dataset ({len(timestep_file_map)}) is less than the specified number of timesteps ({num_timesteps})."
+        )
 
     # Ensure we process only the specified number of timesteps from the end
     timesteps = list(timestep_file_map.items())[-num_timesteps:]
@@ -154,18 +159,33 @@ def calculate_avg_qevent_ratio(
     average_q_event_ratio = q_event_ratios_df["q_event_ratio"].mean()
     std_dev_q_event_ratio = q_event_ratios_df["q_event_ratio"].std()
 
-    # Save the results
-    q_event_ratios_df.to_csv("q_event_ratios.csv", index=False)
+    # Save the results to `averaged_data_path` as csv files
+    q_event_ratios_df.to_csv(
+        os.path.join(averaged_data_path, "q_event_ratio_history.csv"), index=False
+    )
+    logger.info(
+        "Q event ratio history saved to %s",
+        os.path.join(averaged_data_path, "q_event_ratio_history.csv"),
+    )
+
     summary_df = pd.DataFrame(
         {
             "average_q_event_ratio": [average_q_event_ratio],
             "std_dev_q_event_ratio": [std_dev_q_event_ratio],
+            "H_value": [H],  # Include the H value
         }
     )
-    summary_df.to_csv("q_event_summary.csv", index=False)
+    summary_df.to_csv(
+        os.path.join(averaged_data_path, "q_event_ratio_summary.csv"), index=False
+    )
+    logger.info(
+        "Q event ratio summary saved to %s",
+        os.path.join(averaged_data_path, "q_event_ratio_summary.csv"),
+    )
 
     logger.info(f"Average Q Event Volume Ratio: {average_q_event_ratio}")
     logger.info(f"Standard Deviation of Q Event Volume Ratio: {std_dev_q_event_ratio}")
+    logger.info(f"H value used: {H}\n")  # Log the H value used
 
 
 if __name__ == "__main__":

--- a/DRL_POL/calc_avg_qvolume.py
+++ b/DRL_POL/calc_avg_qvolume.py
@@ -173,7 +173,9 @@ if __name__ == "__main__":
 
     # HARDCODED PATHS FOR TESTING
     directory = "/scratch/pietero/baseline/prados_recent/re180_min_channel_900_calculating_Ubar/vtk_for_average/vtk"
-    averaged_data_path = "/scratch/pietero/andres_clone/DRL_POL/alya_files/baseline/calculated_data/"
+    averaged_data_path = (
+        "/scratch/pietero/andres_clone/DRL_POL/alya_files/baseline/calculated_data/"
+    )
     H = 3.0
     num_timesteps = 10
 

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -184,6 +184,12 @@ def process_velocity_data_single(
     #     unique_y_averaged.head(20),
     # )
 
+    # print whether the unique y values are EXACTLY the same
+    logger.debug(
+        "Are the unique y values the same?\n\n%s!!!\n\n",
+        unique_y_main.equals(unique_y_averaged),
+    )
+
     # Select 5 rows with a specific y value before the merge
     sample_y_value = unique_y_main.index[5]  # Taking the first y value as sample
     df_sample_before_merge = df[df["y"] == sample_y_value].head(10)

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -106,10 +106,10 @@ def normalize_all_single(
     nan_u_count = df_copy["u"].isna().sum()
     nan_v_count = df_copy["v"].isna().sum()
     logger.debug(
-        "%s: Number of NaNs in 'u' after normalization: %d", timestep, nan_u_count
+        "normalize_all_single: %s: Number of NaNs in 'u' after normalization: %d", timestep, nan_u_count
     )
     logger.debug(
-        "%s: Number of NaNs in 'v' after normalization: %d", timestep, nan_v_count
+        "normalize_all_single: %s: Number of NaNs in 'v' after normalization: %d", timestep, nan_v_count
     )
 
     logger.info("Data normalization complete.")
@@ -169,16 +169,16 @@ def process_velocity_data_single(
     nan_U_count = df_processed["U"].isna().sum()
     nan_V_count = df_processed["V"].isna().sum()
     logger.debug(
-        "%s: Number of NaNs in 'u' after processing: %d", timestep, nan_u_count
+        "process_velocity_data_single: %s: Number of NaNs in 'u' after processing: %d", timestep, nan_u_count
     )
     logger.debug(
-        "%s: Number of NaNs in 'v' after processing: %d", timestep, nan_v_count
+        "process_velocity_data_single: %s: Number of NaNs in 'v' after processing: %d", timestep, nan_v_count
     )
     logger.debug(
-        "%s: Number of NaNs in 'U' after processing: %d", timestep, nan_U_count
+        "process_velocity_data_single: %s: Number of NaNs in 'U' after processing: %d", timestep, nan_U_count
     )
     logger.debug(
-        "%s: Number of NaNs in 'V' after processing: %d", timestep, nan_V_count
+        "process_velocity_data_single: %s: Number of NaNs in 'V' after processing: %d", timestep, nan_V_count
     )
 
     logger.info("Velocity data processing complete.")

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -156,9 +156,9 @@ def process_velocity_data_single(
     df["y"] = df["y"].round(precision)
     averaged_data["y"] = averaged_data["y"].round(precision)
 
-    # Convert 'y' values to numeric types to ensure consistency
-    df["y"] = pd.to_numeric(df["y"])
-    averaged_data["y"] = pd.to_numeric(averaged_data["y"])
+    # Convert 'y' values to float64 to ensure consistency
+    df["y"] = df["y"].astype('float64')
+    averaged_data["y"] = averaged_data["y"].astype('float64')
 
     # Check and log data types of 'y' columns
     logger.debug(

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -450,7 +450,8 @@ def calculate_reward_full(
 
     # Add ENV_ID column to result_df
     result_df["ENV_ID"] = result_df.apply(
-        lambda row: agent_index_2d_to_1d(row["x_index"], row["z_index"], nz), axis=1
+        lambda row: int(agent_index_2d_to_1d(row["x_index"], row["z_index"], nz)),
+        axis=1,
     )
 
     all_results.append(result_df)

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -106,10 +106,14 @@ def normalize_all_single(
     nan_u_count = df_copy["u"].isna().sum()
     nan_v_count = df_copy["v"].isna().sum()
     logger.debug(
-        "normalize_all_single: %s: Number of NaNs in 'u' after normalization: %d", timestep, nan_u_count
+        "normalize_all_single: %s: Number of NaNs in 'u' after normalization: %d",
+        timestep,
+        nan_u_count,
     )
     logger.debug(
-        "normalize_all_single: %s: Number of NaNs in 'v' after normalization: %d", timestep, nan_v_count
+        "normalize_all_single: %s: Number of NaNs in 'v' after normalization: %d",
+        timestep,
+        nan_v_count,
     )
 
     logger.info("Data normalization complete.")
@@ -136,6 +140,28 @@ def process_velocity_data_single(
     timestep, df = timestep_df
     logger.info("Processing velocity data using loaded averaged data...")
 
+    # Check for NaN values in the initial dataframe
+    nan_u_initial = df["u"].isna().sum()
+    nan_v_initial = df["v"].isna().sum()
+    logger.debug(
+        "process_velocity_data_single: %s: Initial NaNs in 'u': %d",
+        timestep,
+        nan_u_initial,
+    )
+    logger.debug(
+        "process_velocity_data_single: %s: Initial NaNs in 'v': %d",
+        timestep,
+        nan_v_initial,
+    )
+
+    # Check the structure of averaged_data
+    logger.debug(
+        "process_velocity_data_single: averaged_data columns: %s", averaged_data.columns
+    )
+    logger.debug(
+        "process_velocity_data_single: averaged_data sample: %s", averaged_data.head()
+    )
+
     # Process the dataset for detailed fluctuation analysis
     # y_means = averaged_data.loc[df["y"]]
     # logger.debug(f"y_means: {y_means}")
@@ -144,11 +170,31 @@ def process_velocity_data_single(
 
     df_merged = pd.merge(df, averaged_data, on="y", how="left")
 
+    # Log the result of the merge
+    nan_U_bar = df_merged["U_bar"].isna().sum()
+    nan_V_bar = df_merged["V_bar"].isna().sum()
+    nan_W_bar = df_merged["W_bar"].isna().sum()
+    logger.debug(
+        "process_velocity_data_single: %s: NaNs in 'U_bar' after merge: %d",
+        timestep,
+        nan_U_bar,
+    )
+    logger.debug(
+        "process_velocity_data_single: %s: NaNs in 'V_bar' after merge: %d",
+        timestep,
+        nan_V_bar,
+    )
+    logger.debug(
+        "process_velocity_data_single: %s: NaNs in 'W_bar' after merge: %d",
+        timestep,
+        nan_W_bar,
+    )
+
     df_processed = df.copy()
 
-    logger.debug(f"df_processed columns: {df_processed.columns.tolist()}")
-    logger.debug(f"df_processed index: {df_processed.index}")
-    logger.debug(f"df_processed y values: {df_processed['y'].values}")
+    # logger.debug(f"df_processed columns: {df_processed.columns.tolist()}")
+    # logger.debug(f"df_processed index: {df_processed.index}")
+    # logger.debug(f"df_processed y values: {df_processed['y'].values}")
     df_processed["U"] = df["u"]
     df_processed["V"] = df["v"]
     df_processed["W"] = df["w"]
@@ -169,16 +215,24 @@ def process_velocity_data_single(
     nan_U_count = df_processed["U"].isna().sum()
     nan_V_count = df_processed["V"].isna().sum()
     logger.debug(
-        "process_velocity_data_single: %s: Number of NaNs in 'u' after processing: %d", timestep, nan_u_count
+        "process_velocity_data_single: %s: Number of NaNs in 'u' after processing: %d",
+        timestep,
+        nan_u_count,
     )
     logger.debug(
-        "process_velocity_data_single: %s: Number of NaNs in 'v' after processing: %d", timestep, nan_v_count
+        "process_velocity_data_single: %s: Number of NaNs in 'v' after processing: %d",
+        timestep,
+        nan_v_count,
     )
     logger.debug(
-        "process_velocity_data_single: %s: Number of NaNs in 'U' after processing: %d", timestep, nan_U_count
+        "process_velocity_data_single: %s: Number of NaNs in 'U' after processing: %d",
+        timestep,
+        nan_U_count,
     )
     logger.debug(
-        "process_velocity_data_single: %s: Number of NaNs in 'V' after processing: %d", timestep, nan_V_count
+        "process_velocity_data_single: %s: Number of NaNs in 'V' after processing: %d",
+        timestep,
+        nan_V_count,
     )
 
     logger.info("Velocity data processing complete.")

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -447,7 +447,6 @@ def calculate_reward_full(
 
     result_df = calculate_local_Q_ratios(df, nx, nz, Lx_norm, Lz_norm)
     result_df["timestep"] = timestep
-    all_results.append(result_df)
 
     # Add ENV_ID column to result_df
     result_df["ENV_ID"] = result_df.apply(

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -143,22 +143,13 @@ def process_velocity_data_single(
     timestep, df = timestep_df
     logger.info("Processing velocity data using loaded averaged data...")
 
-    # Check and log data types of 'y' columns
-    logger.debug(
-        "Data type of 'y' in main DataFrame BEFORE converting: %s", df["y"].dtype
-    )
-    logger.debug(
-        "Data type of 'y' in averaged data BEFORE converting: %s",
-        averaged_data["y"].dtype,
-    )
-
     # Ensure y values are rounded to the same precision in both DataFrames
     df["y"] = df["y"].round(precision)
     averaged_data["y"] = averaged_data["y"].round(precision)
 
     # Convert 'y' values to float64 to ensure consistency
-    df["y"] = df["y"].astype('float64')
-    averaged_data["y"] = averaged_data["y"].astype('float64')
+    df["y"] = df["y"].astype("float64")
+    averaged_data["y"] = averaged_data["y"].astype("float64")
 
     # Check and log data types of 'y' columns
     logger.debug(
@@ -193,32 +184,30 @@ def process_velocity_data_single(
         averaged_data.head(),
     )
 
-    # Process the dataset for detailed fluctuation analysis
-    # y_means = averaged_data.loc[df["y"]]
-    # logger.debug(f"y_means: {y_means}")
-    # logger.debug(f"y_means columns: {y_means.columns.tolist()}")
-    # logger.debug(f"y_means index: {y_means.index}")
-
     # Log unique 'y' values and their counts in the main DataFrame
     unique_y_main = df["y"].value_counts().sort_index()
-    # logger.debug(
-    #     "%s: Unique 'y' values in main DataFrame:\n %s\n",
-    #     timestep,
-    #     unique_y_main.head(20),
-    # )
+    logger.debug(
+        "%s: Unique 'y' values in main DataFrame:\n %s\n",
+        timestep,
+        unique_y_main.head(20),
+    )
 
     # Log unique 'y' values and their counts in the averaged data
     unique_y_averaged = averaged_data["y"].value_counts().sort_index()
-    # logger.debug(
-    #     "%s: Unique 'y' values in averaged data:\n %s\n",
-    #     timestep,
-    #     unique_y_averaged.head(20),
-    # )
-
-    # print whether the unique y values are EXACTLY the same
     logger.debug(
-        "Are the unique y values the same?\n\n%s!!!\n\n",
-        unique_y_main.equals(unique_y_averaged),
+        "%s: Unique 'y' values in averaged data:\n %s\n",
+        timestep,
+        unique_y_averaged.head(20),
+    )
+
+    # Compare and log differences in 'y' values
+    y_in_main_not_in_averaged = set(unique_y_main.index) - set(unique_y_averaged.index)
+    y_in_averaged_not_in_main = set(unique_y_averaged.index) - set(unique_y_main.index)
+    logger.debug(
+        "Y values in main DataFrame not in averaged data: %s", y_in_main_not_in_averaged
+    )
+    logger.debug(
+        "Y values in averaged data not in main DataFrame: %s", y_in_averaged_not_in_main
     )
 
     # Select 5 rows with a specific y value before the merge

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -157,11 +157,11 @@ def process_velocity_data_single(
     # iterate through each row of main dataframe and manually assign the rounded value to the 'y' column
     df_altered_copy = df.copy()
     for index, row in df.iterrows():
-        df_altered_copy.at[index, "y"] = np.round(row["y"], precision)
+        df_altered_copy.at[index, "y"] = np.round(row["y"], 3)
 
     averaged_data_copy = averaged_data.copy()
     for index, row in averaged_data.iterrows():
-        averaged_data_copy.at[index, "y"] = np.round(row["y"], precision)
+        averaged_data_copy.at[index, "y"] = np.round(row["y"], 3)
 
     # # Apply rounding to 'y' values using pandas.DataFrame.round
     # df_altered_copy = df.copy()
@@ -198,12 +198,6 @@ def process_velocity_data_single(
     # Convert 'y' values to float64 to ensure consistency
     df["y"] = df["y"].astype("float64")
     averaged_data["y"] = averaged_data["y"].astype("float64")
-
-    # Verify the rounding operation
-    logger.debug("Rounded 'y' values in main DataFrame: \n%s\n", df["y"].unique())
-    logger.debug(
-        "Rounded 'y' values in averaged data: \n%s\n", averaged_data["y"].unique()
-    )
 
     # Check and log data types of 'y' columns
     logger.debug(

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -146,12 +146,6 @@ def process_velocity_data_single(
     precision: int = 3
     tolerance: float = 1e-3
 
-    # Print 'y' values before adjustment
-    logger.debug("Original 'y' values in main DataFrame:\n%s", df["y"].unique())
-    logger.debug(
-        "Original 'y' values in averaged data:\n%s", averaged_data["y"].unique()
-    )
-
     # Adjust 'y' values in averaged data to match main data if within tolerance
     main_y_unique = df["y"].unique()
     averaged_y_unique = averaged_data["y"].unique()
@@ -159,41 +153,14 @@ def process_velocity_data_single(
     for main_y in main_y_unique:
         for i, avg_y in enumerate(averaged_y_unique):
             if np.abs(main_y - avg_y) <= tolerance:
+                logger.debug(
+                    f"Overwriting averaged y value {avg_y} with main y value {main_y}"
+                )
                 averaged_data.loc[averaged_data["y"] == avg_y, "y"] = main_y
                 averaged_y_unique[i] = (
                     main_y  # Update the unique values list to reflect the change
                 )
                 break
-
-    # Print 'y' values after adjustment
-    logger.debug("Adjusted 'y' values in main DataFrame:\n%s", df["y"].unique())
-    logger.debug(
-        "Adjusted 'y' values in averaged data:\n%s", averaged_data["y"].unique()
-    )
-
-    # Check for NaN values in the initial dataframe
-    nan_u_initial = df["u"].isna().sum()
-    nan_v_initial = df["v"].isna().sum()
-    logger.debug(
-        "process_velocity_data_single: %s: Initial NaNs in 'u': %d",
-        timestep,
-        nan_u_initial,
-    )
-    logger.debug(
-        "process_velocity_data_single: %s: Initial NaNs in 'v': %d",
-        timestep,
-        nan_v_initial,
-    )
-
-    # Check the structure of averaged_data
-    logger.debug(
-        "process_velocity_data_single: averaged_data columns: \n%s\n",
-        averaged_data.columns,
-    )
-    logger.debug(
-        "process_velocity_data_single: averaged_data sample: \n%s\n",
-        averaged_data.head(),
-    )
 
     # Log unique 'y' values and their counts in the main DataFrame
     unique_y_main = df["y"].value_counts().sort_index()
@@ -233,31 +200,12 @@ def process_velocity_data_single(
     df_sample_after_merge = df_merged[df_merged["y"] == sample_y_value].head(10)
     logger.debug("Sample rows after merge:\n%s", df_sample_after_merge)
 
-    # Log the result of the merge
-    nan_U_bar = df_merged["U_bar"].isna().sum()
-    nan_V_bar = df_merged["V_bar"].isna().sum()
-    nan_W_bar = df_merged["W_bar"].isna().sum()
-    logger.debug(
-        "process_velocity_data_single: %s: NaNs in 'U_bar' after merge: %d",
-        timestep,
-        nan_U_bar,
-    )
-    logger.debug(
-        "process_velocity_data_single: %s: NaNs in 'V_bar' after merge: %d",
-        timestep,
-        nan_V_bar,
-    )
-    logger.debug(
-        "process_velocity_data_single: %s: NaNs in 'W_bar' after merge: %d",
-        timestep,
-        nan_W_bar,
-    )
-
     df_processed = df.copy()
 
-    # logger.debug(f"df_processed columns: {df_processed.columns.tolist()}")
-    # logger.debug(f"df_processed index: {df_processed.index}")
-    # logger.debug(f"df_processed y values: {df_processed['y'].values}")
+    logger.debug(f"df_processed columns: {df_processed.columns.tolist()}")
+    logger.debug(f"df_processed index: {df_processed.index}")
+    logger.debug(f"df_processed y values: {df_processed['y'].values}")
+
     df_processed["U"] = df["u"]
     df_processed["V"] = df["v"]
     df_processed["W"] = df["w"]

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -170,12 +170,19 @@ def process_velocity_data_single(
 
     # Log unique 'y' values and their counts in the main DataFrame
     unique_y_main = df["y"].value_counts().sort_index()
-    logger.debug("%s: Unique 'y' values in main DataFrame:\n %s\n", timestep, unique_y_main.head(20))
+    logger.debug(
+        "%s: Unique 'y' values in main DataFrame:\n %s\n",
+        timestep,
+        unique_y_main.head(20),
+    )
 
     # Log unique 'y' values and their counts in the averaged data
     unique_y_averaged = averaged_data["y"].value_counts().sort_index()
-    logger.debug("%s: Unique 'y' values in averaged data:\n %s\n", timestep, unique_y_averaged.head(20))
-
+    logger.debug(
+        "%s: Unique 'y' values in averaged data:\n %s\n",
+        timestep,
+        unique_y_averaged.head(20),
+    )
 
     df_merged = pd.merge(df, averaged_data, on="y", how="left")
 

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -123,7 +123,7 @@ def normalize_all_single(
 def process_velocity_data_single(
     timestep_df: Tuple[float, pd.DataFrame],
     averaged_data: pd.DataFrame,
-    precision: int = 5,
+    precision: int = 4,
 ) -> Tuple[float, pd.DataFrame]:
     """
     Processes a tuple containing CFD simulation data to calculate fluctuating components of velocity fields.

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -146,8 +146,11 @@ def process_velocity_data_single(
     precision: int = 3
 
     # Ensure y values are rounded to the same precision in both DataFrames
-    df["y"] = np.round(df["y"], precision)
-    averaged_data["y"] = np.round(averaged_data["y"], precision)
+    # df["y"] = np.round(df["y"], precision)
+    # averaged_data["y"] = np.round(averaged_data["y"], precision)
+
+    df["y"] = df.round({"y": precision})
+    averaged_data["y"] = averaged_data.round({"y": precision})
 
     # Convert 'y' values to float64 to ensure consistency
     df["y"] = df["y"].astype("float64")

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -143,6 +143,15 @@ def process_velocity_data_single(
     timestep, df = timestep_df
     logger.info("Processing velocity data using loaded averaged data...")
 
+    # Check and log data types of 'y' columns
+    logger.debug(
+        "Data type of 'y' in main DataFrame BEFORE converting: %s", df["y"].dtype
+    )
+    logger.debug(
+        "Data type of 'y' in averaged data BEFORE converting: %s",
+        averaged_data["y"].dtype,
+    )
+
     # Ensure y values are rounded to the same precision in both DataFrames
     df["y"] = df["y"].round(precision)
     averaged_data["y"] = averaged_data["y"].round(precision)
@@ -152,8 +161,13 @@ def process_velocity_data_single(
     averaged_data["y"] = pd.to_numeric(averaged_data["y"])
 
     # Check and log data types of 'y' columns
-    logger.debug("Data type of 'y' in main DataFrame: %s", df["y"].dtype)
-    logger.debug("Data type of 'y' in averaged data: %s", averaged_data["y"].dtype)
+    logger.debug(
+        "Data type of 'y' in main DataFrame AFTER converting: %s", df["y"].dtype
+    )
+    logger.debug(
+        "Data type of 'y' in averaged data AFTER converting: %s",
+        averaged_data["y"].dtype,
+    )
 
     # Check for NaN values in the initial dataframe
     nan_u_initial = df["u"].isna().sum()

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -163,10 +163,10 @@ def process_velocity_data_single(
 
     # Check the structure of averaged_data
     logger.debug(
-        "process_velocity_data_single: averaged_data columns: %s", averaged_data.columns
+        "process_velocity_data_single: averaged_data columns: \n%s\n", averaged_data.columns
     )
     logger.debug(
-        "process_velocity_data_single: averaged_data sample: %s", averaged_data.head()
+        "process_velocity_data_single: averaged_data sample: \n%s\n", averaged_data.head()
     )
 
     # Process the dataset for detailed fluctuation analysis

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -145,12 +145,34 @@ def process_velocity_data_single(
 
     precision: int = 3
 
+    # Print 'y' values before rounding
+    logger.debug(
+        "Original 'y' values in main DataFrame before rounding:\n%s", df["y"].unique()
+    )
+    logger.debug(
+        "Original 'y' values in averaged data before rounding:\n%s",
+        averaged_data["y"].unique(),
+    )
+
+    # Apply rounding to 'y' values using pandas.DataFrame.round
+    df["y"] = df["y"].round(precision)
+    averaged_data["y"] = averaged_data["y"].round(precision)
+
+    # Print 'y' values after rounding
+    logger.debug(
+        "Rounded 'y' values in main DataFrame after rounding:\n%s", df["y"].unique()
+    )
+    logger.debug(
+        "Rounded 'y' values in averaged data after rounding:\n%s",
+        averaged_data["y"].unique(),
+    )
+
     # Ensure y values are rounded to the same precision in both DataFrames
     # df["y"] = np.round(df["y"], precision)
     # averaged_data["y"] = np.round(averaged_data["y"], precision)
-
-    df["y"] = df.round({"y": precision})
-    averaged_data["y"] = averaged_data.round({"y": precision})
+    #
+    # df["y"] = df.round({"y": precision})
+    # averaged_data["y"] = averaged_data.round({"y": precision})
 
     # Convert 'y' values to float64 to ensure consistency
     df["y"] = df["y"].astype("float64")

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -121,7 +121,7 @@ def normalize_all_single(
 
 
 def process_velocity_data_single(
-    timestep_df: Tuple[float, pd.DataFrame], averaged_data: pd.DataFrame
+    timestep_df: Tuple[float, pd.DataFrame], averaged_data: pd.DataFrame, precision: int = 6
 ) -> Tuple[float, pd.DataFrame]:
     """
     Processes a tuple containing CFD simulation data to calculate fluctuating components of velocity fields.
@@ -132,6 +132,7 @@ def process_velocity_data_single(
       and velocity components (u, v, w). (NORMALIZED!)
     - averaged_data (DataFrame): Contains averaged velocities ($\overline{U}(y)$, $\overline{V}(y)$, $\overline{W}(y)$)
       and rms of velocity fluctuations ($u'(y)$, $v'(y)$, $w'(y)$) as columns, indexed by the y-coordinate. (NORMALIZED!)
+    - precision (int): The number of decimal places to round the 'y' values to. Ensures they are recognized as equal!
 
     Returns:
     - processed_data (tuple): A tuple containing a timestep and a DataFrame with original and fluctuating
@@ -139,6 +140,10 @@ def process_velocity_data_single(
     """
     timestep, df = timestep_df
     logger.info("Processing velocity data using loaded averaged data...")
+
+    # Ensure y values are rounded to the same precision in both DataFrames
+    df["y"] = df["y"].round(precision)
+    averaged_data["y"] = averaged_data["y"].round(precision)
 
     # Check for NaN values in the initial dataframe
     nan_u_initial = df["u"].isna().sum()

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -151,6 +151,12 @@ def process_velocity_data_single(
     df["y"] = df["y"].astype("float64")
     averaged_data["y"] = averaged_data["y"].astype("float64")
 
+    # Verify the rounding operation
+    logger.debug("Rounded 'y' values in main DataFrame: \n%s\n", df["y"].unique())
+    logger.debug(
+        "Rounded 'y' values in averaged data: \n%s\n", averaged_data["y"].unique()
+    )
+
     # Check and log data types of 'y' columns
     logger.debug(
         "Data type of 'y' in main DataFrame AFTER converting: %s", df["y"].dtype

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -147,12 +147,17 @@ def process_velocity_data_single(
 
     # Print 'y' values before rounding
     logger.debug(
-        "Original 'y' values in main DataFrame before rounding:\n%s", df["y"].unique()
+        "Original 'y' values in main DataFrame before rounding:\n%s",
+        sorted(df["y"].unique()),
     )
     logger.debug(
         "Original 'y' values in averaged data before rounding:\n%s",
-        averaged_data["y"].unique(),
+        sorted(averaged_data["y"].unique()),
     )
+
+    # Convert 'y' values to float64 to ensure consistency
+    df["y"] = df["y"].astype("float64")
+    averaged_data["y"] = averaged_data["y"].astype("float64")
 
     # iterate through each row of main dataframe and manually assign the rounded value to the 'y' column
     df_altered_copy = df.copy()
@@ -195,10 +200,6 @@ def process_velocity_data_single(
     #
     # df["y"] = df.round({"y": precision})
     # averaged_data["y"] = averaged_data.round({"y": precision})
-
-    # Convert 'y' values to float64 to ensure consistency
-    df["y"] = df["y"].astype("float64")
-    averaged_data["y"] = averaged_data["y"].astype("float64")
 
     # Check and log data types of 'y' columns
     logger.debug(

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -147,6 +147,14 @@ def process_velocity_data_single(
     df["y"] = df["y"].round(precision)
     averaged_data["y"] = averaged_data["y"].round(precision)
 
+    # Convert 'y' values to numeric types to ensure consistency
+    df["y"] = pd.to_numeric(df["y"])
+    averaged_data["y"] = pd.to_numeric(averaged_data["y"])
+
+    # Check and log data types of 'y' columns
+    logger.debug("Data type of 'y' in main DataFrame: %s", df["y"].dtype)
+    logger.debug("Data type of 'y' in averaged data: %s", averaged_data["y"].dtype)
+
     # Check for NaN values in the initial dataframe
     nan_u_initial = df["u"].isna().sum()
     nan_v_initial = df["v"].isna().sum()

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -102,6 +102,16 @@ def normalize_all_single(
     df_copy["y"] = df_copy["y"] / delta_tau
     df_copy["z"] = df_copy["z"] / delta_tau
 
+    # Log NaN counts
+    nan_u_count = df_copy["u"].isna().sum()
+    nan_v_count = df_copy["v"].isna().sum()
+    logger.debug(
+        "%s: Number of NaNs in 'u' after normalization: %d", timestep, nan_u_count
+    )
+    logger.debug(
+        "%s: Number of NaNs in 'v' after normalization: %d", timestep, nan_v_count
+    )
+
     logger.info("Data normalization complete.")
     return timestep, df_copy
 
@@ -152,6 +162,24 @@ def process_velocity_data_single(
 
     # Ensure no 'timestep' column remains in the output data
     df_processed.drop(columns="timestep", inplace=True, errors="ignore")
+
+    # Log NaN counts
+    nan_u_count = df_processed["u"].isna().sum()
+    nan_v_count = df_processed["v"].isna().sum()
+    nan_U_count = df_processed["U"].isna().sum()
+    nan_V_count = df_processed["V"].isna().sum()
+    logger.debug(
+        "%s: Number of NaNs in 'u' after processing: %d", timestep, nan_u_count
+    )
+    logger.debug(
+        "%s: Number of NaNs in 'v' after processing: %d", timestep, nan_v_count
+    )
+    logger.debug(
+        "%s: Number of NaNs in 'U' after processing: %d", timestep, nan_U_count
+    )
+    logger.debug(
+        "%s: Number of NaNs in 'V' after processing: %d", timestep, nan_V_count
+    )
 
     logger.info("Velocity data processing complete.")
 

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -179,6 +179,12 @@ def detect_Q_events_single(
     logger.info("Detecting Q events...")
     timestep, df = timestep_df
 
+    # Check for NaN values in u and v columns
+    nan_u_count = df["u"].isna().sum()
+    nan_v_count = df["v"].isna().sum()
+    logger.debug("%s: Number of NaNs in 'u': %d", timestep, nan_u_count)
+    logger.debug("%s: Number of NaNs in 'v': %d", timestep, nan_v_count)
+
     # Fetch the rms values for 'u' and 'v' based on y-coordinate
     rms_values = (
         averaged_data.set_index("y")[["u_prime", "v_prime"]].reindex(df["y"]).values

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -135,6 +135,7 @@ def process_velocity_data_single(
     df_merged = pd.merge(df, averaged_data, on="y", how="left")
 
     df_processed = df.copy()
+
     logger.debug(f"df_processed columns: {df_processed.columns.tolist()}")
     logger.debug(f"df_processed index: {df_processed.index}")
     logger.debug(f"df_processed y values: {df_processed['y'].values}")
@@ -144,6 +145,10 @@ def process_velocity_data_single(
     df_processed["u"] = df["u"] - df_merged["U_bar"]
     df_processed["v"] = df["v"] - df_merged["V_bar"]
     df_processed["w"] = df["w"] - df_merged["W_bar"]
+
+    logger.debug(f"NEW df_processed columns: {df_processed.columns.tolist()}")
+    logger.debug(f"NEW df_processed index: {df_processed.index}")
+    logger.debug(f"NEW df_processed y values: {df_processed['y'].values}")
 
     # Ensure no 'timestep' column remains in the output data
     df_processed.drop(columns="timestep", inplace=True, errors="ignore")

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -190,6 +190,7 @@ def detect_Q_events_single(
 
     # Create DataFrame with Q event boolean flag
     q_df = pd.DataFrame({"x": df["x"], "y": df["y"], "z": df["z"], "Q": q_events})
+    logger.debug("%s: number of Q events detected: %d", timestep, q_events.sum())
 
     logger.info("Q event detection complete.")
 

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -143,6 +143,8 @@ def process_velocity_data_single(
     timestep, df = timestep_df
     logger.info("Processing velocity data using loaded averaged data...")
 
+    precision: int = 3
+
     # Ensure y values are rounded to the same precision in both DataFrames
     df["y"] = np.round(df["y"], precision)
     averaged_data["y"] = np.round(averaged_data["y"], precision)

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -154,11 +154,17 @@ def process_velocity_data_single(
         averaged_data["y"].unique(),
     )
 
-    # Apply rounding to 'y' values using pandas.DataFrame.round
-    df_altered_copy = df.copy()
-    df_altered_copy["y"] = df["y"].round(precision)
-    averaged_data_copy = averaged_data.copy()
-    averaged_data_copy["y"] = averaged_data["y"].round(precision)
+    # iterate through each row of main dataframe and manually assign the rounded value to the 'y' column
+    for index, row in df.iterrows():
+        df.at[index, "y"] = np.round(row["y"], precision)
+    for index, row in averaged_data.iterrows():
+        averaged_data.at[index, "y"] = np.round(row["y"], precision)
+
+    # # Apply rounding to 'y' values using pandas.DataFrame.round
+    # df_altered_copy = df.copy()
+    # df_altered_copy["y"] = df["y"].round(precision)
+    # averaged_data_copy = averaged_data.copy()
+    # averaged_data_copy["y"] = averaged_data["y"].round(precision)
 
     # Print 'y' values after rounding
     logger.debug(

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -171,32 +171,6 @@ def process_velocity_data_single(
         "Adjusted 'y' values in averaged data:\n%s", averaged_data["y"].unique()
     )
 
-    # Check if altered 'y' values are equal to the original 'y' values
-    logger.debug(
-        "Are 'y' values in main DataFrame equal to altered 'y' values? %s",
-        df["y"].equals(df_altered_copy["y"]),
-    )
-    logger.debug(
-        "Are 'y' values in averaged data equal to altered 'y' values? %s",
-        averaged_data["y"].equals(averaged_data_copy["y"]),
-    )
-
-    # Ensure y values are rounded to the same precision in both DataFrames
-    # df["y"] = np.round(df["y"], precision)
-    # averaged_data["y"] = np.round(averaged_data["y"], precision)
-    #
-    # df["y"] = df.round({"y": precision})
-    # averaged_data["y"] = averaged_data.round({"y": precision})
-
-    # Check and log data types of 'y' columns
-    logger.debug(
-        "Data type of 'y' in main DataFrame AFTER converting: %s", df["y"].dtype
-    )
-    logger.debug(
-        "Data type of 'y' in averaged data AFTER converting: %s",
-        averaged_data["y"].dtype,
-    )
-
     # Check for NaN values in the initial dataframe
     nan_u_initial = df["u"].isna().sum()
     nan_v_initial = df["v"].isna().sum()

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -155,8 +155,10 @@ def process_velocity_data_single(
     )
 
     # Apply rounding to 'y' values using pandas.DataFrame.round
-    df["y"] = df["y"].round(precision)
-    averaged_data["y"] = averaged_data["y"].round(precision)
+    df_altered_copy = df.copy()
+    df_altered_copy["y"] = df["y"].round(precision)
+    averaged_data_copy = averaged_data.copy()
+    averaged_data_copy["y"] = averaged_data["y"].round(precision)
 
     # Print 'y' values after rounding
     logger.debug(
@@ -165,6 +167,16 @@ def process_velocity_data_single(
     logger.debug(
         "Rounded 'y' values in averaged data after rounding:\n%s",
         averaged_data["y"].unique(),
+    )
+
+    # Check if altered 'y' values are equal to the original 'y' values
+    logger.debug(
+        "Are 'y' values in main DataFrame equal to altered 'y' values? %s",
+        df["y"].equals(df_altered_copy["y"]),
+    )
+    logger.debug(
+        "Are 'y' values in averaged data equal to altered 'y' values? %s",
+        averaged_data["y"].equals(averaged_data_copy["y"]),
     )
 
     # Ensure y values are rounded to the same precision in both DataFrames

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -167,7 +167,7 @@ def detect_Q_events_single(
     Parameters:
     - timestep_df (tuple): Data processed by `process_velocity_data_single`, containing:
       * A timestep (float)
-      * A DataFrame with spatial coordinates (x, y, z) and velocity components U, V, W, u, v, w (NORMALIZED!)
+      * A DataFrame with spatial coordinates (x, y, z) and velocity components u, v, w, U, V, W (NORMALIZED!)
     - averaged_data (DataFrame): Data containing the rms values for velocity components u and v for each y coordinate. ** u' and v' **
     - H (float): The sensitivity threshold for identifying Q events.
 
@@ -183,12 +183,17 @@ def detect_Q_events_single(
     rms_values = (
         averaged_data.set_index("y")[["u_prime", "v_prime"]].reindex(df["y"]).values
     )
+    logger.debug("%s: Number of RMS values: %d", timestep, len(rms_values))
 
     # Calculate the product of fluctuating components u and v
     uv_product = np.abs(df["u"] * df["v"])
+    logger.debug("%s: Number of uv products: %d", timestep, len(uv_product))
+    logger.debug("%s: uv_product: %s", timestep, uv_product)
 
     # Calculate the threshold product of rms values u' and v'
     threshold = H * rms_values[:, 0] * rms_values[:, 1]
+    logger.debug("%s: Number of threshold values: %d", timestep, len(threshold))
+    logger.debug("%s: Threshold: %s", timestep, threshold)
 
     # Determine where the Q event condition is met
     q_events = uv_product > threshold  # to avoid detection on 0

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -171,11 +171,12 @@ def process_velocity_data_single(
 
     # Print 'y' values after rounding
     logger.debug(
-        "Rounded 'y' values in main DataFrame after rounding:\n%s", df["y"].unique()
+        "Rounded 'y' values in main DataFrame after rounding:\n%s",
+        sorted(df["y"].unique()),
     )
     logger.debug(
         "Rounded 'y' values in averaged data after rounding:\n%s",
-        averaged_data["y"].unique(),
+        sorted(averaged_data["y"].unique()),
     )
 
     # Check if altered 'y' values are equal to the original 'y' values

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -168,6 +168,15 @@ def process_velocity_data_single(
     # logger.debug(f"y_means columns: {y_means.columns.tolist()}")
     # logger.debug(f"y_means index: {y_means.index}")
 
+    # Log unique 'y' values and their counts in the main DataFrame
+    unique_y_main = df["y"].value_counts().sort_index()
+    logger.debug("%s: Unique 'y' values in main DataFrame:\n %s\n", timestep, unique_y_main.head(20))
+
+    # Log unique 'y' values and their counts in the averaged data
+    unique_y_averaged = averaged_data["y"].value_counts().sort_index()
+    logger.debug("%s: Unique 'y' values in averaged data:\n %s\n", timestep, unique_y_averaged.head(20))
+
+
     df_merged = pd.merge(df, averaged_data, on="y", how="left")
 
     # Log the result of the merge

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -121,7 +121,9 @@ def normalize_all_single(
 
 
 def process_velocity_data_single(
-    timestep_df: Tuple[float, pd.DataFrame], averaged_data: pd.DataFrame, precision: int = 6
+    timestep_df: Tuple[float, pd.DataFrame],
+    averaged_data: pd.DataFrame,
+    precision: int = 5,
 ) -> Tuple[float, pd.DataFrame]:
     """
     Processes a tuple containing CFD simulation data to calculate fluctuating components of velocity fields.
@@ -196,7 +198,7 @@ def process_velocity_data_single(
     )
 
     # Select 5 rows with a specific y value before the merge
-    sample_y_value = unique_y_main.index[5]  # Taking the first y value as sample
+    sample_y_value = unique_y_main.index[2]  # Taking the first y value as sample
     df_sample_before_merge = df[df["y"] == sample_y_value].head(10)
     logger.debug("Sample rows before merge:\n%s", df_sample_before_merge)
 

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -170,21 +170,31 @@ def process_velocity_data_single(
 
     # Log unique 'y' values and their counts in the main DataFrame
     unique_y_main = df["y"].value_counts().sort_index()
-    logger.debug(
-        "%s: Unique 'y' values in main DataFrame:\n %s\n",
-        timestep,
-        unique_y_main.head(20),
-    )
+    # logger.debug(
+    #     "%s: Unique 'y' values in main DataFrame:\n %s\n",
+    #     timestep,
+    #     unique_y_main.head(20),
+    # )
 
     # Log unique 'y' values and their counts in the averaged data
     unique_y_averaged = averaged_data["y"].value_counts().sort_index()
-    logger.debug(
-        "%s: Unique 'y' values in averaged data:\n %s\n",
-        timestep,
-        unique_y_averaged.head(20),
-    )
+    # logger.debug(
+    #     "%s: Unique 'y' values in averaged data:\n %s\n",
+    #     timestep,
+    #     unique_y_averaged.head(20),
+    # )
 
+    # Select 5 rows with a specific y value before the merge
+    sample_y_value = unique_y_main.index[0]  # Taking the first y value as sample
+    df_sample_before_merge = df[df["y"] == sample_y_value].head(10)
+    logger.debug("Sample rows before merge:\n%s", df_sample_before_merge)
+
+    # Process the dataset for detailed fluctuation analysis
     df_merged = pd.merge(df, averaged_data, on="y", how="left")
+
+    # Select the same 5 rows after the merge
+    df_sample_after_merge = df_merged[df_merged["y"] == sample_y_value].head(10)
+    logger.debug("Sample rows after merge:\n%s", df_sample_after_merge)
 
     # Log the result of the merge
     nan_U_bar = df_merged["U_bar"].isna().sum()

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -144,8 +144,8 @@ def process_velocity_data_single(
     logger.info("Processing velocity data using loaded averaged data...")
 
     # Ensure y values are rounded to the same precision in both DataFrames
-    df["y"] = df["y"].round(precision)
-    averaged_data["y"] = averaged_data["y"].round(precision)
+    df["y"] = np.round(df["y"], precision)
+    averaged_data["y"] = np.round(averaged_data["y"], precision)
 
     # Convert 'y' values to float64 to ensure consistency
     df["y"] = df["y"].astype("float64")

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -123,7 +123,7 @@ def normalize_all_single(
 def process_velocity_data_single(
     timestep_df: Tuple[float, pd.DataFrame],
     averaged_data: pd.DataFrame,
-    precision: int = 4,
+    precision: int = 3,
 ) -> Tuple[float, pd.DataFrame]:
     """
     Processes a tuple containing CFD simulation data to calculate fluctuating components of velocity fields.
@@ -163,10 +163,12 @@ def process_velocity_data_single(
 
     # Check the structure of averaged_data
     logger.debug(
-        "process_velocity_data_single: averaged_data columns: \n%s\n", averaged_data.columns
+        "process_velocity_data_single: averaged_data columns: \n%s\n",
+        averaged_data.columns,
     )
     logger.debug(
-        "process_velocity_data_single: averaged_data sample: \n%s\n", averaged_data.head()
+        "process_velocity_data_single: averaged_data sample: \n%s\n",
+        averaged_data.head(),
     )
 
     # Process the dataset for detailed fluctuation analysis

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -185,7 +185,7 @@ def process_velocity_data_single(
     # )
 
     # Select 5 rows with a specific y value before the merge
-    sample_y_value = unique_y_main.index[0]  # Taking the first y value as sample
+    sample_y_value = unique_y_main.index[5]  # Taking the first y value as sample
     df_sample_before_merge = df[df["y"] == sample_y_value].head(10)
     logger.debug("Sample rows before merge:\n%s", df_sample_before_merge)
 

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -155,10 +155,13 @@ def process_velocity_data_single(
     )
 
     # iterate through each row of main dataframe and manually assign the rounded value to the 'y' column
+    df_altered_copy = df.copy()
     for index, row in df.iterrows():
-        df.at[index, "y"] = np.round(row["y"], precision)
+        df_altered_copy.at[index, "y"] = np.round(row["y"], precision)
+
+    averaged_data_copy = averaged_data.copy()
     for index, row in averaged_data.iterrows():
-        averaged_data.at[index, "y"] = np.round(row["y"], precision)
+        averaged_data_copy.at[index, "y"] = np.round(row["y"], precision)
 
     # # Apply rounding to 'y' values using pandas.DataFrame.round
     # df_altered_copy = df.copy()

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -144,44 +144,31 @@ def process_velocity_data_single(
     logger.info("Processing velocity data using loaded averaged data...")
 
     precision: int = 3
+    tolerance: float = 1e-3
 
-    # Print 'y' values before rounding
+    # Print 'y' values before adjustment
+    logger.debug("Original 'y' values in main DataFrame:\n%s", df["y"].unique())
     logger.debug(
-        "Original 'y' values in main DataFrame before rounding:\n%s",
-        sorted(df["y"].unique()),
-    )
-    logger.debug(
-        "Original 'y' values in averaged data before rounding:\n%s",
-        sorted(averaged_data["y"].unique()),
+        "Original 'y' values in averaged data:\n%s", averaged_data["y"].unique()
     )
 
-    # Convert 'y' values to float64 to ensure consistency
-    df["y"] = df["y"].astype("float64")
-    averaged_data["y"] = averaged_data["y"].astype("float64")
+    # Adjust 'y' values in averaged data to match main data if within tolerance
+    main_y_unique = df["y"].unique()
+    averaged_y_unique = averaged_data["y"].unique()
 
-    # iterate through each row of main dataframe and manually assign the rounded value to the 'y' column
-    df_altered_copy = df.copy()
-    for index, row in df.iterrows():
-        df_altered_copy.at[index, "y"] = np.round(row["y"], 3)
+    for main_y in main_y_unique:
+        for i, avg_y in enumerate(averaged_y_unique):
+            if np.abs(main_y - avg_y) <= tolerance:
+                averaged_data.loc[averaged_data["y"] == avg_y, "y"] = main_y
+                averaged_y_unique[i] = (
+                    main_y  # Update the unique values list to reflect the change
+                )
+                break
 
-    averaged_data_copy = averaged_data.copy()
-    for index, row in averaged_data.iterrows():
-        averaged_data_copy.at[index, "y"] = np.round(row["y"], 3)
-
-    # # Apply rounding to 'y' values using pandas.DataFrame.round
-    # df_altered_copy = df.copy()
-    # df_altered_copy["y"] = df["y"].round(precision)
-    # averaged_data_copy = averaged_data.copy()
-    # averaged_data_copy["y"] = averaged_data["y"].round(precision)
-
-    # Print 'y' values after rounding
+    # Print 'y' values after adjustment
+    logger.debug("Adjusted 'y' values in main DataFrame:\n%s", df["y"].unique())
     logger.debug(
-        "Rounded 'y' values in main DataFrame after rounding:\n%s",
-        sorted(df["y"].unique()),
-    )
-    logger.debug(
-        "Rounded 'y' values in averaged data after rounding:\n%s",
-        sorted(averaged_data["y"].unique()),
+        "Adjusted 'y' values in averaged data:\n%s", averaged_data["y"].unique()
     )
 
     # Check if altered 'y' values are equal to the original 'y' values

--- a/DRL_POL/coco_calc_reward.py
+++ b/DRL_POL/coco_calc_reward.py
@@ -412,7 +412,7 @@ def calculate_reward_full(
     delta_tau = precalc_values.iloc[1, 1]
 
     # Load global Q event average ratio and standard deviation
-    q_event_summary_filename = "q_event_summary.csv"
+    q_event_summary_filename = "q_event_ratio_summary.csv"
     q_event_summary_filepath = os.path.join(
         averaged_data_path, q_event_summary_filename
     )

--- a/DRL_POL/logging_config.py
+++ b/DRL_POL/logging_config.py
@@ -100,8 +100,12 @@ def configure_logger(module_name: str, default_level: str = "INFO") -> logging.L
             console_level = default_level.upper()
             file_level = default_level.upper()
     else:
+        config = None
         console_level = default_level.upper()
         file_level = default_level.upper()
+
+    if config is None:
+        raise ValueError(f"Module {module_name} not found in logging_config_dict")
 
     # Clear existing handlers if override is specified
     if config.get("override", False):

--- a/DRL_POL/logging_config.py
+++ b/DRL_POL/logging_config.py
@@ -52,7 +52,7 @@ logging_config_dict: Dict[str, Dict[str, Any]] = {
     "coco_calc_reward": {
         "console_level": "DEBUG",
         "file_level": "DEBUG",
-        "override": False,
+        "override": True,
     },
     "cr": {
         "console_level": "WARNING",

--- a/DRL_POL/logging_config.py
+++ b/DRL_POL/logging_config.py
@@ -39,6 +39,11 @@ logging_config_dict: Dict[str, Dict[str, Any]] = {
         "file_level": "DEBUG",
         "override": False,
     },
+    "calc_avg_qvolume": {
+        "console_level": "INFO",
+        "file_level": "DEBUG",
+        "override": True,
+    },
     "coco_calc_avg_vel": {
         "console_level": "DEBUG",
         "file_level": "DEBUG",

--- a/DRL_POL/logging_config.py
+++ b/DRL_POL/logging_config.py
@@ -52,7 +52,7 @@ logging_config_dict: Dict[str, Dict[str, Any]] = {
     "coco_calc_reward": {
         "console_level": "DEBUG",
         "file_level": "DEBUG",
-        "override": True,
+        "override": False,
     },
     "cr": {
         "console_level": "WARNING",


### PR DESCRIPTION
Added script to calculate the average global Q event volume ratio from a specified number of timesteps from the baseline VTK data (same as average velocity/`u_tau`/`delta_tau`).

Updated reward calculation to scale reward based on local Q event volume ratio compared to the average global ratio.

New reward equation is:

`reward` = 1 − ( `q_ratio` / `avg_qratio` )